### PR TITLE
chore: Add automated linting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'com.diffplug.spotless' version '6.25.0'
 }
 
 group = 'com.example'
@@ -67,4 +68,29 @@ dependencies {
 
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+}
+
+spotless {
+    java {
+        googleJavaFormat().aosp()
+        importOrder('java', 'javax', 'jakarta', 'org', 'com')
+        removeUnusedImports()
+        trimTrailingWhitespace()
+        endWithNewline()
+    }
+}
+
+tasks.register('updateGitHooks', Copy) {
+    from './scripts/pre-commit'
+    into './.git/hooks'
+}
+
+tasks.register('makeGitHooksExecutable', Exec) {
+    commandLine 'chmod', '+x', './.git/hooks/pre-commit'
+    dependsOn updateGitHooks
+}
+
+tasks.named('compileJava') {
+    dependsOn 'makeGitHooksExecutable'
+    dependsOn 'spotlessCheck'
 }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+# From https://github.com/diffplug/spotless/issues/178
+
+echo '[git hook] executing gradle spotlessCheck before commit'
+git stash -q --keep-index
+sh ./gradlew spotlessCheck --daemon
+
+RESULT=$?
+git stash pop -q
+
+exit $RESULT


### PR DESCRIPTION
### Description
프로젝트의 커밋이나 빌드 과정에서 코드 포맷을 검사하도록 하는 설정을 추가한다.

### Related Issues
- Improvised Issue

### Changes Made
- 미리 정의된 규칙에 알맞게 코드가 formatting되지 않으면 다음의 행위가 불가합니다:
  - 변경 사항을 commit 할 수 없음
  - compile 되지 않음

### Screenshots or Video
<img width="683" alt="image" src="https://github.com/user-attachments/assets/2038f1eb-79dc-4095-99aa-eeee9a4dfb87">

### Testing
해당 없음

### Checklist
해당 없음

### Additional Notes
- 포맷팅 규칙은 다음을 참고하여 `build.gradle`내 `spotless`에 정의합니다.
  - https://github.com/diffplug/spotless/blob/gradle/6.25.0/plugin-gradle/README.md

- 다음 두 command를 사용할 수 있습니다
  - check: `./gradlew spotlessCheck`
  - apply (정의된 규칙에 맞게 formatting 진행): `./gradlew spotlessApply`